### PR TITLE
Update main.yml

### DIFF
--- a/roles/generate_report/tasks/main.yml
+++ b/roles/generate_report/tasks/main.yml
@@ -8,19 +8,6 @@
   become: true
   delegate_to: localhost
 
-- name: Include selinux role
-  vars:
-    selinux_fcontexts:
-      - {
-          target: "{{ file_path }}(/.*)?",
-          setype: "httpd_sys_content_t",
-          state: "present",
-        }
-    ansible_python_interpreter: /usr/bin/python3
-
-  ansible.builtin.include_role:
-    name: fedora.linux_system_roles.selinux
-
 - name: Ensure Nginx container is running
   containers.podman.podman_container:
     name: nginx_container


### PR DESCRIPTION
The playbook was attempting to use the fedora.linux_system_roles.selinux role to set SELinux file contexts on a directory ({{ file_path }}) located within the Ansible Automation Platform (AAP) Execution Environment (EE). This failed with a ValueError: SELinux policy is not managed or store cannot be accessed because EE containers do not have a fully manageable SELinux policy store for semanage to interact with.

Why it failed: EEs don't have a full SELinux policy system that semanage can modify from within.

Correct method already in place: The :Z flag on the Podman volume mount correctly handles the SELinux relabeling at the Podman daemon level.